### PR TITLE
Tag Task

### DIFF
--- a/Git.xcodeproj/project.pbxproj
+++ b/Git.xcodeproj/project.pbxproj
@@ -9,6 +9,17 @@
 /* Begin PBXBuildFile section */
 		3FB69FC12790CFD4002AD767 /* TagTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FC02790CFD4002AD767 /* TagTask.swift */; };
 		3FB69FC32790CFE4002AD767 /* GitTagOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FC22790CFE4002AD767 /* GitTagOptions.swift */; };
+		3FB69FC72791C935002AD767 /* TagTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FC62791C935002AD767 /* TagTest.swift */; };
+		3FB69FC82791CA54002AD767 /* TagTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FC02790CFD4002AD767 /* TagTask.swift */; };
+		3FB69FC92791CA54002AD767 /* GitTagOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FC22790CFE4002AD767 /* GitTagOptions.swift */; };
+		3FB69FCB2791D9DC002AD767 /* GitRepository+Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FCA2791D9DC002AD767 /* GitRepository+Tag.swift */; };
+		3FB69FCC2791D9DC002AD767 /* GitRepository+Tag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FCA2791D9DC002AD767 /* GitRepository+Tag.swift */; };
+		3FB69FCE2791DA8D002AD767 /* GitTagRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FCD2791DA8D002AD767 /* GitTagRecord.swift */; };
+		3FB69FCF2791DA8D002AD767 /* GitTagRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FCD2791DA8D002AD767 /* GitTagRecord.swift */; };
+		3FB69FD12791DA99002AD767 /* GitTagRecordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FD02791DA99002AD767 /* GitTagRecordList.swift */; };
+		3FB69FD22791DA99002AD767 /* GitTagRecordList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FD02791DA99002AD767 /* GitTagRecordList.swift */; };
+		3FB69FD42791DB12002AD767 /* RepositoryTagRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FD32791DB12002AD767 /* RepositoryTagRecord.swift */; };
+		3FB69FD52791DB12002AD767 /* RepositoryTagRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FD32791DB12002AD767 /* RepositoryTagRecord.swift */; };
 		560B1A8623FFE90D00E110DE /* AddTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560B1A8523FFE90D00E110DE /* AddTask.swift */; };
 		560B1A8723FFE90D00E110DE /* AddTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560B1A8523FFE90D00E110DE /* AddTask.swift */; };
 		560B1A8923FFE93200E110DE /* GitAddOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560B1A8823FFE93200E110DE /* GitAddOptions.swift */; };
@@ -237,6 +248,11 @@
 /* Begin PBXFileReference section */
 		3FB69FC02790CFD4002AD767 /* TagTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTask.swift; sourceTree = "<group>"; };
 		3FB69FC22790CFE4002AD767 /* GitTagOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTagOptions.swift; sourceTree = "<group>"; };
+		3FB69FC62791C935002AD767 /* TagTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTest.swift; sourceTree = "<group>"; };
+		3FB69FCA2791D9DC002AD767 /* GitRepository+Tag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitRepository+Tag.swift"; sourceTree = "<group>"; };
+		3FB69FCD2791DA8D002AD767 /* GitTagRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTagRecord.swift; sourceTree = "<group>"; };
+		3FB69FD02791DA99002AD767 /* GitTagRecordList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTagRecordList.swift; sourceTree = "<group>"; };
+		3FB69FD32791DB12002AD767 /* RepositoryTagRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryTagRecord.swift; sourceTree = "<group>"; };
 		560B1A8523FFE90D00E110DE /* AddTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTask.swift; sourceTree = "<group>"; };
 		560B1A8823FFE93200E110DE /* GitAddOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitAddOptions.swift; sourceTree = "<group>"; };
 		560B1A8B23FFECF000E110DE /* GitRepository+Files.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitRepository+Files.swift"; sourceTree = "<group>"; };
@@ -390,6 +406,14 @@
 			path = Tag;
 			sourceTree = "<group>";
 		};
+		3FB69FC52791C844002AD767 /* TagTest */ = {
+			isa = PBXGroup;
+			children = (
+				3FB69FC62791C935002AD767 /* TagTest.swift */,
+			);
+			path = TagTest;
+			sourceTree = "<group>";
+		};
 		560B1A8423FFE8EC00E110DE /* Add */ = {
 			isa = PBXGroup;
 			children = (
@@ -467,6 +491,7 @@
 				7BF42947256850CD0064DDB2 /* GitRepository+Reference.swift */,
 				7BA20DE926B1EF13005EA305 /* GitRepository+Remotes.swift */,
 				7B3EC4E123F1ACB700FCCE3B /* GitRepository+Status.swift */,
+				3FB69FCA2791D9DC002AD767 /* GitRepository+Tag.swift */,
 			);
 			path = GitRepository;
 			sourceTree = "<group>";
@@ -739,6 +764,7 @@
 				8406B5DB217202A900E381FD /* LogTest */,
 				84BD16C320D314C10038F377 /* FileManagement */,
 				84076624219E0E6100872938 /* StashTest */,
+				3FB69FC52791C844002AD767 /* TagTest */,
 				84B122C420C887D100DCAAAA /* Info.plist */,
 				84B122BB20C8875600DCAAAA /* CredentialsProviderTest.swift */,
 				84B122E820C9FD1300DCAAAA /* JSONFormatterTest.swift */,
@@ -755,11 +781,12 @@
 				845D243F20C37F9800130D6E /* Repository.swift */,
 				7B41888A26B582DE00145F1E /* RepositoryDelegate.swift */,
 				7BACCD8024485CDE000ECC06 /* RepositoryError.swift */,
+				84EF21272172264A0030667A /* RepositoryLogRecord.swift */,
 				84B122DC20C9E04500DCAAAA /* RepositoryReference.swift */,
 				7B41888426B5692400145F1E /* RepositoryReferenceName.swift */,
 				561497B0211DA1CB00EF4574 /* RepositoryRemote.swift */,
-				84EF21272172264A0030667A /* RepositoryLogRecord.swift */,
 				84076613219E0A7D00872938 /* RepositoryStashRecord.swift */,
+				3FB69FD32791DB12002AD767 /* RepositoryTagRecord.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -785,6 +812,8 @@
 				7BB2A7A823F161FE00C27EAA /* GitFileStatus.swift */,
 				7BB2A7B423F19F6E00C27EAA /* GitFileStatusList.swift */,
 				7B52D66223F297AA00D8684E /* GitMergeStatus.swift */,
+				3FB69FCD2791DA8D002AD767 /* GitTagRecord.swift */,
+				3FB69FD02791DA99002AD767 /* GitTagRecordList.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -1033,13 +1062,16 @@
 				7B3EC4E223F1ACCA00FCCE3B /* GitRepository+Status.swift in Sources */,
 				561497B3211DAC7300EF4574 /* GitRemoteList.swift in Sources */,
 				560B1A8923FFE93200E110DE /* GitAddOptions.swift in Sources */,
+				3FB69FCE2791DA8D002AD767 /* GitTagRecord.swift in Sources */,
 				84E331DF21A33A4500E4D620 /* StashApplyTask.swift in Sources */,
 				7BB2A79E23F1450700C27EAA /* MergeTask.swift in Sources */,
 				84DB399F2172184900EC5D97 /* GitLogOptions.swift in Sources */,
 				568E1B2923F6AE3B00E67274 /* GitResetOptions.swift in Sources */,
 				5673ED7C2126DD7500083229 /* GitPushOptions.swift in Sources */,
 				7BB2A7A123F145C300C27EAA /* MergeOptions.swift in Sources */,
+				3FB69FD42791DB12002AD767 /* RepositoryTagRecord.swift in Sources */,
 				561497AF211DA19C00EF4574 /* GitRemote.swift in Sources */,
+				3FB69FCB2791D9DC002AD767 /* GitRepository+Tag.swift in Sources */,
 				8407984F21B12636008F72F5 /* StashDropTask.swift in Sources */,
 				7BF42955256854010064DDB2 /* BranchTask.swift in Sources */,
 				56839F4A212ACFB200E161E9 /* RemoteUrlChangeTask.swift in Sources */,
@@ -1089,6 +1121,7 @@
 				7BB63383246AFF3500E0DDE9 /* GitOutputParser.swift in Sources */,
 				3FB69FC32790CFE4002AD767 /* GitTagOptions.swift in Sources */,
 				7B33BF60243E24560037C818 /* CherryPickTask.swift in Sources */,
+				3FB69FD12791DA99002AD767 /* GitTagRecordList.swift in Sources */,
 				7BACCD88244868CE000ECC06 /* CleanOptions.swift in Sources */,
 				7BACCD852448687B000ECC06 /* CleanTask.swift in Sources */,
 				84B83764211B7DA40031AD29 /* ArgumentConvertible.swift in Sources */,
@@ -1107,6 +1140,7 @@
 				7B4F07E9243F18D5009560DA /* GitRepository+CherryPick.swift in Sources */,
 				7BF42956256854010064DDB2 /* BranchTask.swift in Sources */,
 				7B52D66423F297AA00D8684E /* GitMergeStatus.swift in Sources */,
+				3FB69FCF2791DA8D002AD767 /* GitTagRecord.swift in Sources */,
 				7B110F9223B153FC00DBD3CA /* GitLogRecord.swift in Sources */,
 				84B83765211B7DA40031AD29 /* ArgumentConvertible.swift in Sources */,
 				84B122E720C9EDBC00DCAAAA /* GitFormatEncoder.swift in Sources */,
@@ -1122,11 +1156,14 @@
 				5673ED792126CB5200083229 /* CommitTask.swift in Sources */,
 				7B33BF61243E24560037C818 /* CherryPickTask.swift in Sources */,
 				7BB2A7A223F145C300C27EAA /* MergeOptions.swift in Sources */,
+				3FB69FC72791C935002AD767 /* TagTest.swift in Sources */,
+				3FB69FC82791CA54002AD767 /* TagTask.swift in Sources */,
 				56466BA9211DBFDD001EF6C3 /* RemoteRenameTask.swift in Sources */,
 				84B122DE20C9E04500DCAAAA /* RepositoryReference.swift in Sources */,
 				84B122BC20C8875600DCAAAA /* CredentialsProviderTest.swift in Sources */,
 				7B239D7123E4A8D30025D052 /* RepositoryTest.swift in Sources */,
 				7B33BF5E243E201E0037C818 /* CherryPickOptions.swift in Sources */,
+				3FB69FC92791CA54002AD767 /* GitTagOptions.swift in Sources */,
 				84B122C620C8883D00DCAAAA /* CredentialsProvider.swift in Sources */,
 				7BA20DEB26B1EF99005EA305 /* GitRepository+Remotes.swift in Sources */,
 				7B41888C26B582DE00145F1E /* RepositoryDelegate.swift in Sources */,
@@ -1156,6 +1193,7 @@
 				84B122DB20C9C19100DCAAAA /* RepositoryTask.swift in Sources */,
 				7BACCD862448687B000ECC06 /* CleanTask.swift in Sources */,
 				7B239D7323E4AB700025D052 /* LogComparisonTest.swift in Sources */,
+				3FB69FD52791DB12002AD767 /* RepositoryTagRecord.swift in Sources */,
 				7B239D6923E48D020025D052 /* GitLogCompareOptions.swift in Sources */,
 				7B10B58C26AFD344000FA67D /* BranchTest.swift in Sources */,
 				7B10B59626B08439000FA67D /* InitTask.swift in Sources */,
@@ -1200,10 +1238,12 @@
 				84B122DA20C9C18E00DCAAAA /* CloneTask.swift in Sources */,
 				7B10B59826B08557000FA67D /* InitOptions.swift in Sources */,
 				8407985B21B166CA008F72F5 /* GitPullOptions.swift in Sources */,
+				3FB69FD22791DA99002AD767 /* GitTagRecordList.swift in Sources */,
 				84B122E120C9E0B700DCAAAA /* GitReference.swift in Sources */,
 				8408533820D32730005E2AA8 /* FileAnnotationRecord.swift in Sources */,
 				7BA82EC12440B6450046C4DC /* CheckoutOptions.swift in Sources */,
 				56D5FBDB2400256400875B8C /* GitStatusOptions.swift in Sources */,
+				3FB69FCC2791D9DC002AD767 /* GitRepository+Tag.swift in Sources */,
 				84DB399D2172159600EC5D97 /* GitLogRecordList.swift in Sources */,
 				56466BA2211DBBE9001EF6C3 /* GitRemoteList.swift in Sources */,
 				56466BA6211DBC2B001EF6C3 /* GitRemote.swift in Sources */,

--- a/Git.xcodeproj/project.pbxproj
+++ b/Git.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3FB69FC12790CFD4002AD767 /* TagTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FC02790CFD4002AD767 /* TagTask.swift */; };
+		3FB69FC32790CFE4002AD767 /* GitTagOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB69FC22790CFE4002AD767 /* GitTagOptions.swift */; };
 		560B1A8623FFE90D00E110DE /* AddTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560B1A8523FFE90D00E110DE /* AddTask.swift */; };
 		560B1A8723FFE90D00E110DE /* AddTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560B1A8523FFE90D00E110DE /* AddTask.swift */; };
 		560B1A8923FFE93200E110DE /* GitAddOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 560B1A8823FFE93200E110DE /* GitAddOptions.swift */; };
@@ -233,6 +235,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		3FB69FC02790CFD4002AD767 /* TagTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagTask.swift; sourceTree = "<group>"; };
+		3FB69FC22790CFE4002AD767 /* GitTagOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitTagOptions.swift; sourceTree = "<group>"; };
 		560B1A8523FFE90D00E110DE /* AddTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddTask.swift; sourceTree = "<group>"; };
 		560B1A8823FFE93200E110DE /* GitAddOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitAddOptions.swift; sourceTree = "<group>"; };
 		560B1A8B23FFECF000E110DE /* GitRepository+Files.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GitRepository+Files.swift"; sourceTree = "<group>"; };
@@ -377,6 +381,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3FB69FBF2790CFBE002AD767 /* Tag */ = {
+			isa = PBXGroup;
+			children = (
+				3FB69FC22790CFE4002AD767 /* GitTagOptions.swift */,
+				3FB69FC02790CFD4002AD767 /* TagTask.swift */,
+			);
+			path = Tag;
+			sourceTree = "<group>";
+		};
 		560B1A8423FFE8EC00E110DE /* Add */ = {
 			isa = PBXGroup;
 			children = (
@@ -813,6 +826,7 @@
 				568E1B2523F6ADC600E67274 /* Reset */,
 				84076619219E0BC600872938 /* Stash */,
 				7BB2A7B023F1966700C27EAA /* Status */,
+				3FB69FBF2790CFBE002AD767 /* Tag */,
 			);
 			path = Tasks;
 			sourceTree = "<group>";
@@ -1059,6 +1073,7 @@
 				840D89AC20E18802002E09F4 /* GitRepositoryErrorFormatter.swift in Sources */,
 				7BB2A7B223F1969A00C27EAA /* StatusTask.swift in Sources */,
 				7B41888B26B582DE00145F1E /* RepositoryDelegate.swift in Sources */,
+				3FB69FC12790CFD4002AD767 /* TagTask.swift in Sources */,
 				7B110F9123B153F700DBD3CA /* GitLogRecord.swift in Sources */,
 				84B122B420C886FD00DCAAAA /* GitRepository.swift in Sources */,
 				7BC384BC245301BD00511F0B /* CherryTask.swift in Sources */,
@@ -1072,6 +1087,7 @@
 				7B10B59526B08438000FA67D /* InitTask.swift in Sources */,
 				7BACCD8124485CDE000ECC06 /* RepositoryError.swift in Sources */,
 				7BB63383246AFF3500E0DDE9 /* GitOutputParser.swift in Sources */,
+				3FB69FC32790CFE4002AD767 /* GitTagOptions.swift in Sources */,
 				7B33BF60243E24560037C818 /* CherryPickTask.swift in Sources */,
 				7BACCD88244868CE000ECC06 /* CleanOptions.swift in Sources */,
 				7BACCD852448687B000ECC06 /* CleanTask.swift in Sources */,

--- a/Sources/Classes/GitRepository.swift
+++ b/Sources/Classes/GitRepository.swift
@@ -100,17 +100,6 @@ public class GitRepository: Repository {
         try task.run()
     }
 
-    public func tag(options: GitTagOptions) throws {
-        // check for an active operation
-        try ensureNoActiveOperations()
-
-        // local path must be valid
-        try validateLocalPath()
-
-        let task = TagTask(owner: self, options: options)
-        try task.run()
-    }
-
     public func clone(atPath path: String, options: GitCloneOptions = GitCloneOptions.default) throws {
         // check a repository is not cloned yet
         try ensureNotClonedAlready()

--- a/Sources/Classes/GitRepository.swift
+++ b/Sources/Classes/GitRepository.swift
@@ -100,6 +100,17 @@ public class GitRepository: Repository {
         try task.run()
     }
 
+    public func tag(options: GitTagOptions) throws {
+        // check for an active operation
+        try ensureNoActiveOperations()
+
+        // local path must be valid
+        try validateLocalPath()
+
+        let task = TagTask(owner: self, options: options)
+        try task.run()
+    }
+
     public func clone(atPath path: String, options: GitCloneOptions = GitCloneOptions.default) throws {
         // check a repository is not cloned yet
         try ensureNotClonedAlready()

--- a/Sources/Classes/GitRepository/GitRepository+Tag.swift
+++ b/Sources/Classes/GitRepository/GitRepository+Tag.swift
@@ -1,0 +1,44 @@
+//
+//  GitRepository+Tag.swift
+//  Git
+//
+//  Created by Jeremy Greenwood on 1/14/22.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+public extension GitRepository {
+    func tag(options: GitTagOptions) throws {
+        // check for an active operation
+        try ensureNoActiveOperations()
+
+        // local path must be valid
+        try validateLocalPath()
+
+        let task = TagTask(owner: self, options: options)
+        try task.run()
+    }
+
+    func tagList(pattern: String? = nil) throws -> GitTagRecordList {
+        // check for an active operation
+        try ensureNoActiveOperations()
+
+        // local path must be valid
+        try validateLocalPath()
+
+        let task = TagTask(owner: self, options: GitTagOptions.list(pattern))
+        try task.run()
+
+        return task.tags
+    }
+}

--- a/Sources/Classes/GitTagRecord.swift
+++ b/Sources/Classes/GitTagRecord.swift
@@ -1,0 +1,26 @@
+//
+//  GitTagRecord.swift
+//  Git
+//
+//  Created by Jeremy Greenwood on 1/14/22.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+public final class GitTagRecord: RepositoryTagRecord {
+    internal init(tag: String) {
+        self.tag = tag
+    }
+
+    public var tag: String
+}

--- a/Sources/Classes/GitTagRecordList.swift
+++ b/Sources/Classes/GitTagRecordList.swift
@@ -1,0 +1,29 @@
+//
+//  GitTagRecordList.swift
+//  Git
+//
+//  Created by Jeremy Greenwood on 1/14/22.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+public final class GitTagRecordList {
+
+    // MARK: - Public
+    required public init(_ records: [RepositoryTagRecord] = []) {
+        self.records = records
+    }
+
+    // MARK: - Private
+    private(set) public var records: [RepositoryTagRecord]
+}

--- a/Sources/Classes/Tasks/Push/GitPushOptions.swift
+++ b/Sources/Classes/Tasks/Push/GitPushOptions.swift
@@ -45,6 +45,14 @@ public class GitPushOptions: ArgumentConvertible {
         /// ````
         /// Where *origin* is a **remote**, and *master* is a **name** of a branch
         case single(name: String, remote: RepositoryRemote)
+
+        /// All refs under refs/tags are pushed, in addition to refspecs explicitly listed on the command line.
+        ///
+        /// This equals to a raw git command:
+        /// ```
+        /// git push --tags
+        /// ```
+        case tags
         
         func toArguments() -> [String] {
             switch self {
@@ -52,6 +60,8 @@ public class GitPushOptions: ArgumentConvertible {
                 return ["--all"]
             case .single(let name, let remote):
                 return [remote.name, name]
+            case .tags:
+                return ["--tags"]
             }
         }
     }

--- a/Sources/Classes/Tasks/Tag/GitTagOptions.swift
+++ b/Sources/Classes/Tasks/Tag/GitTagOptions.swift
@@ -1,0 +1,33 @@
+//
+//  GitTagOptions.swift
+//  Git-macOS
+//
+//  Created by Jeremy Greenwood on 1/13/22.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+public enum GitTagOptions: ArgumentConvertible {
+    case annotate(_ tag: String, _ message: String)
+    case delete(_ tag: String)
+    case lightWeight(_ tag: String)
+
+    func toArguments() -> [String] {
+        switch self {
+        case let .annotate(tag, message): return ["-a \(tag)", "-m \(message)"]
+
+        case .delete(let tag): return ["-d \(tag)"]
+        case .lightWeight(let tag): return ["\(tag)"]
+        }
+    }
+}

--- a/Sources/Classes/Tasks/Tag/GitTagOptions.swift
+++ b/Sources/Classes/Tasks/Tag/GitTagOptions.swift
@@ -18,22 +18,24 @@
 import Foundation
 
 public enum GitTagOptions: ArgumentConvertible {
-    case annotate(_ tag: String, _ message: String)
+    case annotate(_ tag: String, _ message: String, _ commit: String? = nil)
     case delete(_ tag: String)
-    case lightWeight(_ tag: String)
+    case lightWeight(_ tag: String, _ commit: String? = nil)
     case list(_ pattern: String?)
 
     func toArguments() -> [String] {
         switch self {
-        case let .annotate(tag, message): return ["-a", "\(tag)", "-m", "\(message)"]
-        case .delete(let tag): return ["-d", "\(tag)"]
-        case .lightWeight(let tag): return ["\(tag)"]
-        case .list(let search):
-            guard let search = search else {
-                return ["-l"]
-            }
+        case let .annotate(tag, message, commit):
+            return ["-a", tag, "-m", message, commit].compactMap { $0 }
 
-            return ["-l", "\(search)"]
+        case .delete(let tag):
+            return ["-d", tag]
+
+        case let .lightWeight(tag, commit):
+            return [tag, commit].compactMap { $0 }
+
+        case .list(let pattern):
+            return ["-l", pattern].compactMap { $0 }
         }
     }
 }

--- a/Sources/Classes/Tasks/Tag/GitTagOptions.swift
+++ b/Sources/Classes/Tasks/Tag/GitTagOptions.swift
@@ -21,13 +21,19 @@ public enum GitTagOptions: ArgumentConvertible {
     case annotate(_ tag: String, _ message: String)
     case delete(_ tag: String)
     case lightWeight(_ tag: String)
+    case list(_ pattern: String?)
 
     func toArguments() -> [String] {
         switch self {
-        case let .annotate(tag, message): return ["-a \(tag)", "-m \(message)"]
-
-        case .delete(let tag): return ["-d \(tag)"]
+        case let .annotate(tag, message): return ["-a", "\(tag)", "-m", "\(message)"]
+        case .delete(let tag): return ["-d", "\(tag)"]
         case .lightWeight(let tag): return ["\(tag)"]
+        case .list(let search):
+            guard let search = search else {
+                return ["-l"]
+            }
+
+            return ["-l", "\(search)"]
         }
     }
 }

--- a/Sources/Classes/Tasks/Tag/TagTask.swift
+++ b/Sources/Classes/Tasks/Tag/TagTask.swift
@@ -1,0 +1,32 @@
+//
+//  TagTask.swift
+//  Git-macOS
+//
+//  Created by Jeremy Greenwood on 1/13/22.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+class TagTask: RepositoryTask, TaskRequirable {
+    var name: String { "tag" }
+
+    func handle(output: String) {}
+
+    func handle(errorOutput: String) {}
+
+    func finish(terminationStatus: Int32) throws {
+        guard terminationStatus == 0 else {
+            throw GitError.tagError(message: output ?? "Unknown error")
+        }
+    }
+}

--- a/Sources/Classes/Tasks/Tag/TagTask.swift
+++ b/Sources/Classes/Tasks/Tag/TagTask.swift
@@ -19,6 +19,7 @@ import Foundation
 
 class TagTask: RepositoryTask, TaskRequirable {
     var name: String { "tag" }
+    var tags = GitTagRecordList([])
 
     func handle(output: String) {}
 
@@ -27,6 +28,13 @@ class TagTask: RepositoryTask, TaskRequirable {
     func finish(terminationStatus: Int32) throws {
         guard terminationStatus == 0 else {
             throw GitError.tagError(message: output ?? "Unknown error")
+        }
+
+        if let output = output {
+            tags = GitTagRecordList(
+                output.trimmingCharacters(in: .newlines)
+                    .components(separatedBy: "\n")
+                    .map(GitTagRecord.init(tag:)))
         }
     }
 }

--- a/Sources/Protocols/RepositoryError.swift
+++ b/Sources/Protocols/RepositoryError.swift
@@ -40,6 +40,10 @@ public enum GitError: Error {
     // MARK: - Commit
     /// Occurs when the commit operation finishes with an error
     case commitError(message: String)
+
+    // MARK: - Tag
+    /// Occurs when the tag operation finishes with an error
+    case tagError(message: String)
     
     // MAKR: - Init
     /// Occurs when the init operation finishes with an error
@@ -167,6 +171,7 @@ extension GitError: GitCommonError {
         case .checkoutError(let message): return message
         case .cloneError(let message): return message
         case .commitError(let message): return message
+        case .tagError(let message): return message
         case .stashError(let message): return message
         case .stashApplyError(let message): return message
         case .stashApplyConflict(let message): return message

--- a/Sources/Protocols/RepositoryTagRecord.swift
+++ b/Sources/Protocols/RepositoryTagRecord.swift
@@ -1,0 +1,22 @@
+//
+//  RepositoryTagRecord.swift
+//  Git
+//
+//  Created by Jeremy Greenwood on 1/14/22.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import Foundation
+
+public protocol RepositoryTagRecord {
+    var tag: String { get }
+}

--- a/Tests/TagTest/TagTest.swift
+++ b/Tests/TagTest/TagTest.swift
@@ -45,6 +45,14 @@ class TagTest: XCTestCase, RepositoryTest {
         try repository.tag(options: .lightWeight(Self.tag))
     }
 
+    func testLightWeightWithCommit() throws {
+        let hash = try repository.listLogRecords().records.first!.hash
+        try repository.tag(options: .lightWeight(Self.tag, hash))
+
+        let tag = String.parseRef(try repository.listLogRecords().records.first!.refNames)["tag"]
+        XCTAssert(tag == Self.tag, "Expected \(String(describing: tag)) and \(Self.tag) to be the same")
+    }
+
     func testList() throws {
         try repository.tag(options: .lightWeight(Self.tag))
         try repository.tag(options: .lightWeight(Self.tag2))
@@ -78,5 +86,25 @@ class TagTest: XCTestCase, RepositoryTest {
     func testDelete() throws {
         try repository.tag(options: .lightWeight(Self.tag))
         try repository.tag(options: .delete(Self.tag))
+    }
+}
+
+private extension String {
+    static func parseRef(_ ref: String) -> Dictionary<String, String> {
+        ref.replacingOccurrences(of: " ", with: "")
+            .components(separatedBy: ",")
+            .filter( { $0.contains(":") } )
+            .map { $0.components(separatedBy: ":") }
+            .filter { $0.count == 2 }
+            .map { pair in Dictionary(uniqueKeysWithValues: [(pair[0], pair[1])]) }
+            .reduce([:]) {
+                var combined = $0
+
+                for (k, v) in $1 {
+                    combined[k] = v
+                }
+
+                return combined
+            }
     }
 }

--- a/Tests/TagTest/TagTest.swift
+++ b/Tests/TagTest/TagTest.swift
@@ -1,0 +1,70 @@
+//
+//  TagTest.swift
+//  GitTests
+//
+//  Created by Jeremy Greenwood on 1/14/22.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+import XCTest
+@testable import Git
+
+class TagTest: XCTestCase, RepositoryTest {
+    private static let tag = "test-tag"
+    private static let tag2 = "test-tag-2"
+    private static let message = "This is a test tag"
+
+    var repositoryBundleName: String { "" }
+
+    private var repository: GitRepository!
+
+    override func setUpWithError() throws {
+        repository = try createEmptyRepositoryWithCommit()
+    }
+
+    override func tearDownWithError() throws {
+        if let path = repository?.localPath {
+            FileManager.removeDirectory(atPath: path)
+        }
+    }
+
+    func testAnnotate() throws {
+        try repository.tag(options: .annotate(Self.tag, Self.message))
+    }
+
+    func testLightWeight() throws {
+        try repository.tag(options: .lightWeight(Self.tag))
+    }
+
+    func testList() throws {
+        try repository.tag(options: .lightWeight(Self.tag))
+        try repository.tag(options: .lightWeight(Self.tag2))
+
+        let tagList = try repository.tagList()
+        XCTAssert(tagList.records.contains(where: { $0.tag == Self.tag }), "Expected tag list to contain \(Self.tag), but does not")
+        XCTAssert(tagList.records.contains(where: { $0.tag == Self.tag2 }), "Expected tag list to contain \(Self.tag2), but does not")
+
+        let tagListWithPattern = try repository.tagList(pattern: Self.tag)
+        XCTAssert(tagListWithPattern.records.contains(where: { $0.tag == Self.tag }), "Expected tag list to contain \(Self.tag), but does not")
+        XCTAssertFalse(tagListWithPattern.records.contains(where: { $0.tag == Self.tag2 }), "Tag list unexpectedly contains \(Self.tag2)")
+    }
+
+    func testDeleteTagNotFound() throws {
+        try repository.tag(options: .delete(Self.tag))
+        XCTExpectFailure("Expected to fail since tag is not first created")
+    }
+
+    func testDelete() throws {
+        try repository.tag(options: .lightWeight(Self.tag))
+        try repository.tag(options: .delete(Self.tag))
+    }
+}

--- a/Tests/TagTest/TagTest.swift
+++ b/Tests/TagTest/TagTest.swift
@@ -59,8 +59,20 @@ class TagTest: XCTestCase, RepositoryTest {
     }
 
     func testDeleteTagNotFound() throws {
-        try repository.tag(options: .delete(Self.tag))
-        XCTExpectFailure("Expected to fail since tag is not first created")
+        XCTAssertThrowsError(try repository.tag(options: .delete(Self.tag)), "Expected to fail since tag is not first created") { error in
+            guard let gitError = error as? GitError else {
+                XCTFail("Unexpected Error type.")
+                return
+            }
+
+            switch gitError {
+            case .tagError(let message):
+                XCTAssert(message.contains("not found"), "Unexpected error message")
+                break
+            default:
+                XCTFail("Unexpected Error case.")
+            }
+        }
     }
 
     func testDelete() throws {


### PR DESCRIPTION
### Abstract

This diff seeks to add support for common `git tag` operations. 

### Motivation

Currently this framework supports getting a list of tags via git refs aka `.git/refs/tags`. This is useful, but it would be real nice to able to add and delete tags in addition to listing. 

### Additions

I've added four basic git tag operations to start with: `annotate`, `delete`, `lightWeight`, and `list`.

`annotate` and `lightWeight` both tag `HEAD` by default, but can optionally take a commit associated value. Passing a commit SHA will tag that specific commit.

`list` returns the full tag list by default, but can optionally be passed a matching pattern to filter this list. The pattern supports wildcard syntax for example `v1*`.

I also added `GitPushOptions.BranchOptions.tags` to allow pushing tag refs.

